### PR TITLE
Adding filtering support

### DIFF
--- a/packages/livedoc-mocha/.vscode/launch.json
+++ b/packages/livedoc-mocha/.vscode/launch.json
@@ -23,7 +23,12 @@
                 "build/app/livedoc",
                 "--ui",
                 "livedoc-mocha",
-                "${workspaceRoot}/build/test"
+                "${workspaceRoot}/build/test",
+                "--ld-exclude",
+                "filter:exclude",
+                "--ld-include",
+                "filter:include",
+                "--showFilterConflicts"
             ],
             "sourceMaps": true,
             "outFiles": [

--- a/packages/livedoc-mocha/README.md
+++ b/packages/livedoc-mocha/README.md
@@ -5,6 +5,7 @@ LiveDoc-mocha is a library for adding behavior using a language called [Gherkin]
 
 * [Installing](README.md#Installing)
 * [API reference](README.md#api)
+* [Command line options](README.md#Command-Line)
 * [Why another library?](README.md#why-another-library)
 
 ## So what does this look like?
@@ -24,7 +25,7 @@ Feature: Account Holder withdraws cash
   Scenario: Account has sufficient funds
     Given the account holders account has the following:
         | account | 12345 |
-        | balance | 100   |
+        | balance |   100 |
         | status  | valid |
       And the machine contains 1000 dollars
     When the Account Holder requests 20 dollars
@@ -55,7 +56,7 @@ feature(`Account Holder withdraws cash
 
             given(`the account holders account has the following:
             | account | 12345 |
-            | balance | 100   |
+            | balance |   100 |
             | status  | valid |
         `, () => {
                     const accountHolder = stepContext.tableAsEntity;
@@ -136,6 +137,27 @@ Also for a brief tutorial on how to write Gherkin specs using livedoc-mocha see 
 
 Release notes can be found [here](docs/ReleaseNotes.md)
 
+## Command Line
+livedoc-mocha supports the following command line options. These are useful when wanting to filter the features/scenarios that you want to run:
+
+* <code>--ld-include</code>: Used to only include features/scenarios that have been marked with the tags provided. Example use would be to only run what's been tagged with @integration. 
+
+example:
+```js 
+--ld-include "_tag_ _tag_ _tag_"
+```
+* <code>--ld-exclude</code>: Used to exclude features/scenarios that have been marked with the tags provided. Example use would be run everything __except__ those tagged with @integration. 
+
+example:
+```js 
+--ld-exclude "_tag_ _tag_ _tag_"
+```
+
+* --showFilterConflicts: When used will display conflicted filter matches as pending rather than not showing them at all.
+
+The <code>--ld-include</code> and <code>ld-exclude</code> switches can be used together to both include and exclude features/scenarios. When a conflict occurs by default the exclude will take precedence. However, there may be times when you want to know what the conflicts were. In that case using the <code>--showFilterConflicts</code> will show the otherwise excluded scenarios but mark them as pending, so they are still not executed.
+
+> For more details on tags and tagging, refer to the [Tags](API.md#tags) documentation in teh API reference.
 
 # Why another library?
 There are a number of different libraries that bring the Gherkin language to javascript and even mocha:

--- a/packages/livedoc-mocha/_src/app/livedoc.ts
+++ b/packages/livedoc-mocha/_src/app/livedoc.ts
@@ -480,7 +480,7 @@ class Parser {
         while (textReader.next()) {
             const line = textReader.line.trim();
             if (line.startsWith("@")) {
-                this.tags.push(...line.substr(1).split(' '));
+                this.tags.push(...line.replace('@', '').split(' '));
             } else if (line.toLocaleLowerCase().startsWith("examples")) {
                 // scenario outline table
                 this.tables.push(this.parseTable(textReader));

--- a/packages/livedoc-mocha/_src/app/livedoc.ts
+++ b/packages/livedoc-mocha/_src/app/livedoc.ts
@@ -480,7 +480,7 @@ class Parser {
         while (textReader.next()) {
             const line = textReader.line.trim();
             if (line.startsWith("@")) {
-                this.tags.push(...line.replace('@', '').split(' '));
+                this.tags.push(...line.replace(/@/g, '').split(' '));
             } else if (line.toLocaleLowerCase().startsWith("examples")) {
                 // scenario outline table
                 this.tables.push(this.parseTable(textReader));

--- a/packages/livedoc-mocha/_src/test/Background.Spec.ts
+++ b/packages/livedoc-mocha/_src/test/Background.Spec.ts
@@ -37,24 +37,25 @@ feature(`Background statement
 
         });
 
-        scenario("Add 10 to someValue", () => {
-            when(`someValue is increased by '10'`, () => {
-                someValue += stepContext.values[0];
-            });
+        scenario(`Add 10 to someValue
+            @filter:background-test`, () => {
+                when(`someValue is increased by '10'`, () => {
+                    someValue += stepContext.values[0];
+                });
 
-            then("someValue should be '110'", () => {
-                someValue.should.be.equal(stepContext.values[0]);
-            });
+                then("someValue should be '110'", () => {
+                    someValue.should.be.equal(stepContext.values[0]);
+                });
 
-            and("afterBackgroundCheck should be '10'", () => {
-                afterBackgroundCheck.should.be.equal(stepContext.values[0]);
-            });
+                and("afterBackgroundCheck should be '10'", () => {
+                    afterBackgroundCheck.should.be.equal(stepContext.values[0]);
+                });
 
-            // TODO: Change the number to 1 after optimization
-            and("the background has been executed '1' times so far", () => {
-                count.should.be.equal(stepContext.values[0]);
-            })
-        });
+                // TODO: Change the number to 1 after optimization
+                and("the background has been executed '1' times so far", () => {
+                    count.should.be.equal(stepContext.values[0]);
+                })
+            });
 
         scenario("Add 20 to someValue", () => {
             when(`someValue is increased by '20'`, () => {
@@ -108,7 +109,7 @@ feature(`Background works with Scenario Outlines`, () => {
             });
         })
     scenarioOutline(`Given the following items
-
+        @filter:background-test
         Examples:
         | col1 |
         | row1 |

--- a/packages/livedoc-mocha/_src/test/Background.Spec.ts
+++ b/packages/livedoc-mocha/_src/test/Background.Spec.ts
@@ -95,17 +95,18 @@ feature(`Background statement
 
     });
 
-feature("Background works with Scenario Outlines", () => {
+feature(`Background works with Scenario Outlines`, () => {
     let afterBackgroundCheck = 0;
-    background("Validate afterBackground", () => {
-        given("afterBackgroundCheck has 10 added to it", () => {
-            afterBackgroundCheck += 10;
-        });
+    background(`Validate afterBackground         
+        `, () => {
+            given("afterBackgroundCheck has 10 added to it", () => {
+                afterBackgroundCheck += 10;
+            });
 
-        afterBackground(() => {
-            afterBackgroundCheck = 0;
-        });
-    })
+            afterBackground(() => {
+                afterBackgroundCheck = 0;
+            });
+        })
     scenarioOutline(`Given the following items
 
         Examples:

--- a/packages/livedoc-mocha/_src/test/Feature.Spec.ts
+++ b/packages/livedoc-mocha/_src/test/Feature.Spec.ts
@@ -49,7 +49,7 @@ feature.skip("Features can be skipped", () => {
     })
 });
 
-feature("Scenarios within features can be skipped", () => {
+feature(`Scenarios within features can be skipped`, () => {
     scenario.skip("a scenario within a feature can be skipped", () => {
         given("a skipped scenario, this should not fire!", () => {
             throw Error("This should not have fired! The feature was skipped!");
@@ -64,3 +64,81 @@ feature("Step definitions within scenarios can be skipped", () => {
         })
     })
 });
+
+feature(`Scenarios within features can be skipped via use of tags
+        Note: must run tests with --ld-exclude filter:exclude`, () => {
+        scenario(`this scenario should be run
+            `, () => {
+                given("a non skipped scenario, this should fire!", () => {
+
+                });
+
+                when(`a non skipped scenario has a skipped step via tags it shouldn't run
+                    @filter:exclude`, () => {
+
+                    });
+            });
+
+        scenario(`a scenario within a feature can be skipped
+        @filter:exclude
+        `, () => {
+                given("a skipped scenario, this should not fire!", () => {
+                    throw Error("This should not have fired! The feature was skipped!");
+                });
+            });
+
+        scenarioOutline(`a scenarioOutline within a feature can be skipped
+            @filter:exclude
+
+            Examples:
+            |value|
+            |3|
+            |4|
+            `, () => {
+                given("a skipped scenario, this should not fire! <value>", () => {
+                    throw Error("This should not have fired! The feature was skipped!");
+                });
+            });
+    });
+
+feature(`Features can be skipped via use of tags
+        @filter:exclude
+        Note: must run tests with --ld-exclude filter:exclude`, () => {
+        scenario("a scenario within a skipped feature", () => {
+            given("a skipped feature, this should not fire!", () => {
+                throw Error("This should not have fired! The feature was skipped!");
+            })
+        })
+    });
+
+feature(`Features can be skipped via use of tags
+        Note: must run tests with --ld-exclude filter:exclude`, () => {
+        scenario(`a scenario within a skipped feature
+        @filter:exclude
+        `, () => {
+                given("an always-run scenario, this should fire!", () => {
+
+                });
+            });
+    });
+
+feature(`Features that are marked as include and exclude won't be run
+    @filter:include filter:exclude
+    Note: must run tests with --ld-exclude filter:exclude`, () => {
+        scenario("a scenario within a skipped feature", () => {
+            given("a conflicted filter so can fire!", () => {
+                throw Error("This should not have fired! The feature was skipped!");
+            })
+        })
+    });
+
+feature(`Features can be included via use of tags
+        Note: must run tests with --ld-include filter:include`, () => {
+        scenario(`a scenario within a skipped feature
+        @filter:include
+        `, () => {
+                given("an always-run scenario, this should fire!", () => {
+
+                });
+            });
+    });

--- a/packages/livedoc-mocha/_src/test/Feature.Spec.ts
+++ b/packages/livedoc-mocha/_src/test/Feature.Spec.ts
@@ -116,8 +116,8 @@ feature(`Features can be skipped via use of tags
         scenario(`a scenario within a skipped feature
         @filter:exclude
         `, () => {
-                given("an always-run scenario, this should fire!", () => {
-
+                given("an always-run scenario, this not should fire!", () => {
+                    throw Error("This should not have fired! The feature was skipped!");
                 });
             });
     });

--- a/packages/livedoc-mocha/_src/test/Feature.Spec.ts
+++ b/packages/livedoc-mocha/_src/test/Feature.Spec.ts
@@ -123,7 +123,7 @@ feature(`Features can be skipped via use of tags
     });
 
 feature(`Features that are marked as include and exclude won't be run
-    @filter:include filter:exclude
+    @filter:include @filter:exclude
     Note: must run tests with --ld-exclude filter:exclude`, () => {
         scenario("a scenario within a skipped feature", () => {
             given("a conflicted filter so can fire!", () => {

--- a/packages/livedoc-mocha/docs/ReleaseNotes.md
+++ b/packages/livedoc-mocha/docs/ReleaseNotes.md
@@ -1,6 +1,7 @@
 # Release Notes
 ## 0.3.4
 * Feature: [#52](https://github.com/dotnetprofessional/LiveDoc/issues/52) Support filtering by tags  
+* Feature: [#53](https://github.com/dotnetprofessional/LiveDoc/issues/53) Support explicit and implicit tagging  
 * Docs: Updated docs and refactored them to be clearer.
 
 ## 0.3.3 

--- a/packages/livedoc-mocha/docs/ReleaseNotes.md
+++ b/packages/livedoc-mocha/docs/ReleaseNotes.md
@@ -2,6 +2,7 @@
 ## 0.3.4
 * Feature: [#52](https://github.com/dotnetprofessional/LiveDoc/issues/52) Support filtering by tags  
 * Feature: [#53](https://github.com/dotnetprofessional/LiveDoc/issues/53) Support explicit and implicit tagging  
+* Feature: [#54](https://github.com/dotnetprofessional/LiveDoc/issues/54) When using .only or filters ensure backgrounds are always executed 
 * Docs: Updated docs and refactored them to be clearer.
 
 ## 0.3.3 

--- a/packages/livedoc-mocha/docs/ReleaseNotes.md
+++ b/packages/livedoc-mocha/docs/ReleaseNotes.md
@@ -1,4 +1,8 @@
 # Release Notes
+## 0.3.4
+* Feature: [#52](https://github.com/dotnetprofessional/LiveDoc/issues/52) Support filtering by tags  
+* Docs: Updated docs and refactored them to be clearer.
+
 ## 0.3.3 
 * Feature: [#38](https://github.com/dotnetprofessional/LiveDoc/issues/38) Support comments for Scenario Outlines  
 * Feature: [#46](https://github.com/dotnetprofessional/LiveDoc/issues/46) Throw exception when using Async for Feature/Scenario/ScenarioOutline/Background  

--- a/packages/livedoc-mocha/package.json
+++ b/packages/livedoc-mocha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livedoc-mocha",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": "Garry McGlennon",
   "description": "BDD extensions for Mocha that support LiveDoc reporting.",
   "repository": {
@@ -27,7 +27,8 @@
     "node": "*"
   },
   "scripts": {
-    "test": "mocha --colors --require build/app/livedoc --ui livedoc-mocha --recursive build/test/",
+    "_comment_fitlering_example": "--ld-include filter:include --ld-exclude \"sometag filter:exclude\" --showFilterConflicts",
+    "test": "mocha --colors --require build/app/livedoc --ui livedoc-mocha --recursive build/test/ --ld-exclude filter:exclude",
     "xpretest": "tsc -p . && cls",
     "release-web": "npm run compile-web && npm run compile-web-minify",
     "compile-web": "rimraf release/web && tsc -p tsconfig.web.json",


### PR DESCRIPTION
## 0.3.4
* Feature: [#52](https://github.com/dotnetprofessional/LiveDoc/issues/52) Support filtering by tags  
* Feature: [#53](https://github.com/dotnetprofessional/LiveDoc/issues/53) Support explicit and implicit tagging  
* Feature: [#54](https://github.com/dotnetprofessional/LiveDoc/issues/54) When using .only or filters ensure backgrounds are always executed 
* Docs: Updated docs and refactored them to be clearer.